### PR TITLE
Expand node.js restriction

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "webpack prettier loader",
   "main": "prettier-loader.js",
   "engines": {
-    "node": "8.4.0",
+    "node": ">=4.0.0",
     "npm": "5.4.2"
   },
   "scripts": {


### PR DESCRIPTION
Previously the node.js restriction was specifically version `8.4.0`, which prevents the use of any other `^8.0.0` version. This might not need to be dropped all the way down to `>=4.0.0`, but as I have a lot of projects that use 7 still, I'd prefer not to lock down to the 8 major if possible.

This change is documented [here]

[here]: https://github.com/mysticatea/eslint-plugin-node#-install--usage

_Excerpt:_

```json
{
    "name": "your-module",
    "version": "1.0.0",
    "engines": {
        "node": ">=4.0.0"
    }
}
```
