### PR TITLE
Delete resolveConfigOptions from prettier configuration.

### DIFF
--- a/prettier-loader.js
+++ b/prettier-loader.js
@@ -15,6 +15,7 @@ function getConfig(filePath, loaderOptions) {
     .resolveConfig(filePath, (loaderOptions || {}).resolveConfigOptions)
     .then(config => {
       var mergedConfig = Object.assign({}, config || {}, loaderOptions);
+      delete mergedConfig.resolveConfigOptions;
       configsCache[filePath] = mergedConfig;
       return mergedConfig;
     });


### PR DESCRIPTION
Currently, if passing `resolveConfigOptions` to loader, the option is also passed down to prettier itself, resulting in:

> Ignored unknown option `{ "resolveConfigOptions": <message> }`.

This fixes it.