### PR TITLE
add a flag to skip rewriting source file, only prettier output stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.jsx?$/,
+        test: /\.njk?$/,
         use: [
           {
             loader: 'html-loader',

--- a/README.md
+++ b/README.md
@@ -147,8 +147,46 @@ module.exports = {
               editorconfig: true,
               config: 'config/prettier.config.js'
             },
+
+            // skip rewriting source file.
+            // if true, only prettier the output
+            skipRewritingSource: false,
           },
         }
+      }
+    ]
+  }
+};
+```
+
+### Working with HTML preprocessor
+
+If ou work with HTML preprocessor (Twig, EJS, Nunjucks, ...), you may want to process the output stream.
+Still you don't want the input template to be rewritten with the output.
+In that case, you'll need to tell the loader to keep the source file unchanged.
+
+```js
+// webpack.config.js
+module.exports = {
+  // ...
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        use: [
+          {
+            loader: 'html-loader',
+          },
+          {
+            loader: 'prettier-loader',
+            options: {
+              skipRewritingSource: true,
+            },
+          },
+          {
+            loader: 'nunjucks-html-loader',
+          },
+        ],
       }
     ]
   }

--- a/__tests__/utils/check-output-loader.js
+++ b/__tests__/utils/check-output-loader.js
@@ -1,0 +1,7 @@
+const loaderUtils = require('loader-utils');
+
+module.exports = function (source) {
+    const { checkResult } = loaderUtils.getOptions(this)
+    checkResult(source)
+    return source;
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "jest": {
     "testEnvironment": "node",
-    "collectCoverage": true
+    "collectCoverage": true,
+    "testPathIgnorePatterns": ["__tests__/utils"]
   }
 }

--- a/prettier-loader.js
+++ b/prettier-loader.js
@@ -74,7 +74,7 @@ module.exports = async function(source, map) {
     return callback(null, source, map);
   }
 
-  const config = await getConfig(
+  const { skipRewritingSource, ...config } = await getConfig(
     this.resourcePath,
     loaderUtils.getOptions(this)
   );
@@ -86,7 +86,7 @@ module.exports = async function(source, map) {
     return callback(e);
   }
 
-  if (prettierSource !== source) {
+  if (!skipRewritingSource && prettierSource !== source) {
     try {
       fs.writeFileSync(this.resourcePath, prettierSource);
     } catch (error) {


### PR DESCRIPTION
This loader is perfect if i use HTML file as input.

It fails when it is used after an HTML preprocessor (for example Nunjucks or EJS).

As the loader rewrite source file if source code is different from prettier code, it rewrites root template with the processed code (which is the result of the preprocessed root file). In this use case, it would be great to have a way to disable rewriting file.

Here is an example with nunjuncks :

```
{
	test: /\.njk$/,
	use: [
		{
			loader: "html-loader"
		},
		{
			loader: "prettier-loader",
			options: {
				filepath: "foobar.html",
				skipRewritingSource: true
			}
		},
		{
			loader: "nunjucks-html-loader",
			options: {
				searchPaths: [...glob.sync("./src/njk/")]
			}
		}
	]
};
```

The idea is the same with other preprocessor like EJS.


