### PR TITLE
skipping prettier at webpack startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ module.exports = {
             // skip rewriting source file.
             // if true, only prettier the output
             skipRewritingSource: false,
+
+            // skip prettifying file at startup.
+            // if true, prettier will be triggered after the modification of a file
+            ignoreInitial: false,
           },
         }
       }
@@ -162,7 +166,7 @@ module.exports = {
 
 ### Working with HTML preprocessor
 
-If ou work with HTML preprocessor (Twig, EJS, Nunjucks, ...), you may want to process the output stream.
+If you work with HTML preprocessor (Twig, EJS, Nunjucks, ...), you may want to process the output stream.
 Still you don't want the input template to be rewritten with the output.
 In that case, you'll need to tell the loader to keep the source file unchanged.
 

--- a/prettier-loader.js
+++ b/prettier-loader.js
@@ -63,6 +63,8 @@ function findIgnorePathInParentFolders(folderPath) {
 
 // loader
 
+const loadedFiles = new Set();
+
 module.exports = async function(source, map) {
   this.cacheable();
   const callback = this.async();
@@ -81,10 +83,15 @@ module.exports = async function(source, map) {
     return callback(null, source, map);
   }
 
-  const { skipRewritingSource, ...config } = await getConfig(
+  const { skipRewritingSource, ignoreInitial, ...config } = await getConfig(
     this.resourcePath,
     loaderUtils.getOptions(this)
   );
+
+  if (!!ignoreInitial && !loadedFiles.has(this.resourcePath)) {
+    loadedFiles.add(this.resourcePath);
+    return callback(null, source, map);
+  }
 
   let prettierSource;
   try {


### PR DESCRIPTION
add a flag to skip initial source file processing in order to get a faster bootstrap, files are processed after a future modification

Fix #29 