### PR TITLE
set filepath option to help formatter resolution

### DIFF
--- a/prettier-loader.js
+++ b/prettier-loader.js
@@ -22,7 +22,7 @@ async function getConfig(filePath, loaderOptions) {
   );
 
   const mergedConfig = Object.assign(
-    {},
+    { filepath: filePath },
     outerOptions || {},
     passedToLoaderPrettierOptions
   );


### PR DESCRIPTION
Hello. This commit will fix several issue. 
https://github.com/iamolegga/prettier-loader/issues/8#issue-274492694
https://github.com/prettier/prettier-vscode/issues/955#issue-492449694

I have to use workaround at the moment:

```
{
  enforce: 'pre',
  test: /\.((j|t)sx?)$/,
  exclude: /node_modules/,
  use: (info) => [
    {
      loader: 'prettier-loader',
      options: { filepath: info.realResource },
    },
  ],
}
```